### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": ["hewbie.c@mergington.edu"]
     }
 }
 


### PR DESCRIPTION
## Summary
- add GitHub Skills activity to in-memory catalog
- set schedule to Tuesday, max 10 participants
- add Hewbie C to participants

## Testing
- not run (not requested)

Fixes #6